### PR TITLE
Extension changes

### DIFF
--- a/src/Narochno.Primitives/Parsing/IParserLibrary.cs
+++ b/src/Narochno.Primitives/Parsing/IParserLibrary.cs
@@ -1,5 +1,4 @@
-﻿using Narochno.Primitives.Parsing.Parsers;
-using System;
+﻿using System;
 
 namespace Narochno.Primitives.Parsing
 {

--- a/src/Narochno.Primitives/Parsing/ParserExtensions.cs
+++ b/src/Narochno.Primitives/Parsing/ParserExtensions.cs
@@ -9,6 +9,7 @@
             {
                 return (TType)result.Value;
             }
+
             return new Optional<TType>();
         }
 

--- a/src/Narochno.Primitives/Parsing/ParserExtensions.cs
+++ b/src/Narochno.Primitives/Parsing/ParserExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace Narochno.Primitives.Parsing
+{
+    public static class ParserExtensions
+    {
+        public static Optional<TType> TryParse<TType>(this IParser parser, string input)
+        {
+            var result = parser.TryParse(input);
+            if (result.IsSet)
+            {
+                return (TType)result.Value;
+            }
+            return new Optional<TType>();
+        }
+
+        public static TType Parse<TType>(this IParser parser, string input)
+        {
+            return (TType)parser.Parse(input);
+        }
+    }
+}

--- a/src/Narochno.Primitives/Parsing/ParserLibraryExtensions.cs
+++ b/src/Narochno.Primitives/Parsing/ParserLibraryExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Narochno.Primitives.Parsing.Parsers;
-
-namespace Narochno.Primitives.Parsing
+﻿namespace Narochno.Primitives.Parsing
 {
     public static class ParserLibraryExtensions
     {

--- a/src/Narochno.Primitives/Parsing/StringExtensions.cs
+++ b/src/Narochno.Primitives/Parsing/StringExtensions.cs
@@ -12,12 +12,8 @@ namespace Narochno.Primitives.Parsing
         /// <returns>The Optional <typeparamref name="TType"/> parsed from the string <paramref name="input"/></returns>
         public static Optional<TType> TryParse<TType>(this string input)
         {
-            var result = DefaultParserLibrary.Instance.GetParser<TType>().TryParse(input);
-            if (result.IsSet)
-            {
-                return (TType)result.Value;
-            }
-            return new Optional<TType>();
+            return DefaultParserLibrary.Instance.GetParser<TType>()
+                .TryParse<TType>(input);
         }
 
         /// <summary>
@@ -28,7 +24,8 @@ namespace Narochno.Primitives.Parsing
         /// <returns>The IOptional parsed from the string <paramref name="input"/></returns>
         public static IOptional TryParse(this string input, Type type)
         {
-            return DefaultParserLibrary.Instance.GetParser(type).TryParse(input);
+            return DefaultParserLibrary.Instance.GetParser(type)
+                .TryParse(input);
         }
 
         /// <summary>
@@ -39,7 +36,8 @@ namespace Narochno.Primitives.Parsing
         /// <returns>The type <typeparamref name="TType"/> parsed from the string <paramref name="input"/></returns>
         public static TType Parse<TType>(this string input)
         {
-            return (TType)DefaultParserLibrary.Instance.GetParser<TType>().Parse(input);
+            return DefaultParserLibrary.Instance.GetParser<TType>()
+                .Parse<TType>(input);
         }
 
         /// <summary>
@@ -50,7 +48,8 @@ namespace Narochno.Primitives.Parsing
         /// <returns>The type parsed from the string <paramref name="input"/></returns>
         public static object Parse(this string input, Type type)
         {
-            return DefaultParserLibrary.Instance.GetParser(type).Parse(input);
+            return DefaultParserLibrary.Instance.GetParser(type)
+                .Parse(input);
         }
     }
 }

--- a/src/Narochno.Primitives/project.json
+++ b/src/Narochno.Primitives/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.4.0",
+  "version": "1.5.0",
 
   "authors": [ "alanedwardes" ],
 


### PR DESCRIPTION
Moves code from StringExtensions into ParserExtensions, so IParser can have things like .Parse&lt;T&gt; and .TryParse&lt;T&gt;. It helps if that code is being used in a non-static context: https://github.com/Narochno/Narochno.Primitives#parsing-in-a-non-static-context