### PR TITLE
Fix optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Narochno.Primitives [![Build status](https://ci.appveyor.com/api/projects/status/cp7e8kiashwtrcdd/branch/master?svg=true)](https://ci.appveyor.com/project/Narochno/narochno-primitives/branch/master)
+
 Classes designed to make working with C# code easier.
 
 ## Optional&lt;T&gt;
+
 A generic struct to allow for optional reference values. It allows you to write code that assumes all variables except those wrapped with `Optional<T>` are specified, avoiding the need for null checks and possible null reference exceptions.
 
-It is the same concept as `Nullable<T>`, but can be used for reference types instead of only value types.
+It is the same concept as `Nullable<T>`, but can be used for reference types instead of value types.
 
 ### Example Usage
+
 ```csharp
 public async Task RecordInformation(Information information, Optional<Location> location)
 {
@@ -14,10 +17,10 @@ public async Task RecordInformation(Information information, Optional<Location> 
     document["name"] = information.Name;
     document["email"] = information.Email;
 
-    if (location.IsSet)
+    if (location.HasValue)
     {
-        document["country"] = location.Country;
-        document["city"] = location.City;
+        document["country"] = location.Value.Country;
+        document["city"] = location.Value.City;
     }
 
     await Table.LoadTable(dynamoClient, "Information")
@@ -28,23 +31,32 @@ public async Task RecordInformation(Information information, Optional<Location> 
 The use of `Optional<T>` in the code above to wrap the `Location` object is an explicit way to show that it may not be set, without a null check. Anyone calling and editing the code can see the intent of the parameter from a glance.
 
 ## Generic Parsing
+
 A set of classes to provide parsing of strings into types. Allows a single generic function call to invoke parsers for all primitive types, extendable to be used with custom types.
 
 The library also adds support for enum string values.
 ### Example .Parse&lt;T&gt; Usage
+
 The string extension method `.Parse<T>` or `.Parse(type)` can be used to parse a string to a specific type, and throw an exception if the parse fails.
+
 ```csharp
 int number = "20".Parse<int>();
 float floating = "20.25".Parse<float>();
 ```
+
 ### Example .TryParse&lt;T&gt; Usage
-The string extension method `.TryParse<T>` or `.TryParse(type)` can be used to parse a string to a specific type, returning an optional result (and no exception if the parse fails).
+
+The string extension method `.TryParse<T>` or `.TryParse(type)` can be used to parse a string to a specific type, returning a `Nullable` result (and no exception if the parse fails).
+
 ```csharp
-Optional<int> optionalNumber = "10".TryParse<int>();
-Optional<float> optionalFloat = "10.1".TryParse<float>();
+int? optionalNumber = "10".TryParse<int>();
+float? optionalFloat = "10.1".TryParse<float>();
 ```
+
 ### Example Enum String Parsing
+
 The library can be used to parse strings to enum values decorated with the `EnumString` attribute.
+
 ```csharp
 public enum MyEnum
 {
@@ -58,39 +70,47 @@ MyEnum parsed = "second".Parse<MyEnum>();
 ```
 
 ### Extending Parsers
+
 A custom parser will need to inherit from the `Parser` class, which requires the implementation of two methods.
+
 ```csharp
 public class BoolParser : Parser<bool>
 {
     public override bool Parse(string input) => bool.Parse(input);
 
-    public override Optional<bool> TryParse(string input)
+    public override bool? TryParse(string input)
     {
         bool result;
         if (bool.TryParse(input, out result))
         {
             return result;
         }
-
-        return new Optional<bool>();
+        return null;
     }
 }
 ```
+
 Additional parsers can be added for the static string extension methods `.Parse` and `.TryParse` by adding to the static `Parsers` dictionary in `DefaultParserLibrary`.
+
 ```csharp
 DefaultParserLibrary.Parsers.Add(typeof(MyType), new MyTypeParser());
 ```
+
 ### Parsing in a Non-Static Context
+
 The parsing library provides the `DefaultParserLibrary.Instance` static for convenience. This can be re-assigned in your application to anything that implements the interface `IParserLibrary`.
 
 The `DefaultParserLibrary` can also be instantiated, and used as follows, completely avoiding the static extensions.
+
 ```csharp
 var parser = new DefaultParserLibrary()
     .GetParser<bool>();
 
 bool itIsTrue = parser.Parse<bool>("true");
 ```
+
 Parsing can be used with dependency injection - simply register `DefaultParserLibrary` against the interface `IParserLibrary` in your container and inject into your class constructor. Using the library this way allows you to mock its methods in unit tests.
+
 ```csharp
 var provider = new ServiceCollection()
     .AddTransient<IParserLibrary, DefaultParserLibrary>()

--- a/src/Narochno.Primitives.Json/OptionalJsonConverter.cs
+++ b/src/Narochno.Primitives.Json/OptionalJsonConverter.cs
@@ -21,7 +21,7 @@ namespace Narochno.Primitives.Json
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var optional = value as IOptional;
-            serializer.Serialize(writer, optional.IsSet ? optional.Value : null);
+            serializer.Serialize(writer, optional.HasValue ? optional.Value : null);
         }
     }
 }

--- a/src/Narochno.Primitives.Json/project.json
+++ b/src/Narochno.Primitives.Json/project.json
@@ -1,22 +1,22 @@
 ﻿{
-  "version": "1.4.0",
+    "version": "2.0.0",
 
-  "authors": [ "alanedwardes" ],
+    "authors": [ "alanedwardes", "adamhathcock" ],
 
-  "packOptions": {
-    "tags": [ "primitives" ],
-    "projectUrl": "https://github.com/Narochno/Narochno.Primitives"
-  },
+    "packOptions": {
+        "tags": [ "primitives" ],
+        "projectUrl": "https://github.com/Narochno/Narochno.Primitives"
+    },
 
-  "dependencies": {
-    "Newtonsoft.Json": "9.0.1",
-    "Narochno.Primitives": { "target": "project" }
-  },
+    "dependencies": {
+        "Newtonsoft.Json": "9.0.1",
+        "Narochno.Primitives": { "target": "project" }
+    },
 
-  "frameworks": {
-    "netstandard1.3": {
-      "dependencies": {
-      }
+    "frameworks": {
+        "netstandard1.3": {
+            "dependencies": {
+            }
+        }
     }
-  }
 }

--- a/src/Narochno.Primitives/HexExtensions.cs
+++ b/src/Narochno.Primitives/HexExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Narochno.Primitives
+{
+    public static class HexExtensions
+    {
+        public static string ToHexString(this byte[] ba)
+        {
+            string hex = BitConverter.ToString(ba).ToLowerInvariant();
+            return hex.Replace("-", "");
+        }
+    }
+}

--- a/src/Narochno.Primitives/IOptional.cs
+++ b/src/Narochno.Primitives/IOptional.cs
@@ -1,9 +1,0 @@
-﻿namespace Narochno.Primitives
-{
-    public interface IOptional
-    {
-        bool IsSet { get; }
-        bool NotSet { get; }
-        object Value { get; }
-    }
-}

--- a/src/Narochno.Primitives/IOptional.cs
+++ b/src/Narochno.Primitives/IOptional.cs
@@ -1,0 +1,9 @@
+﻿namespace Narochno.Primitives
+{
+    public interface IOptional
+    {
+        bool HasValue { get; }
+        bool HasNoValue { get; }
+        object Value { get; }
+    }
+}

--- a/src/Narochno.Primitives/Optional.cs
+++ b/src/Narochno.Primitives/Optional.cs
@@ -9,7 +9,7 @@ namespace Narochno.Primitives
 
         public Optional(TValue value)
         {
-            IsSet = value != null;
+            HasValue = value != null;
             this.value = value;
         }
 
@@ -17,7 +17,7 @@ namespace Narochno.Primitives
         {
             get
             {
-                if (NotSet)
+                if (HasNoValue)
                 {
                     throw new InvalidOperationException($"Optional<{typeof(TValue).Name}> is not set");
                 }
@@ -26,8 +26,8 @@ namespace Narochno.Primitives
             }
         }
 
-        public bool NotSet => !IsSet;
-        public bool IsSet { get; }
+        public bool HasNoValue => !HasValue;
+        public bool HasValue { get; }
         object IOptional.Value => Value;
 
         public override string ToString() => value?.ToString() ?? "Not Set";

--- a/src/Narochno.Primitives/Optional.cs
+++ b/src/Narochno.Primitives/Optional.cs
@@ -3,12 +3,13 @@
 namespace Narochno.Primitives
 {
     public struct Optional<TValue> : IOptional
+        where TValue : class
     {
         private readonly TValue value;
 
         public Optional(TValue value)
         {
-            IsSet = true;
+            IsSet = value != null;
             this.value = value;
         }
 

--- a/src/Narochno.Primitives/OptionalExtensions.cs
+++ b/src/Narochno.Primitives/OptionalExtensions.cs
@@ -3,11 +3,13 @@
     public static class OptionalExtensions
     {
         public static Optional<TType> Optional<TType>(this TType value)
+            where TType : class
         {
             return new Optional<TType>(value);
         }
 
         public static Optional<TType> Fallback<TType>(this Optional<TType> value, Optional<TType> fallback)
+            where TType : class
         {
             if (value.IsSet)
             {

--- a/src/Narochno.Primitives/OptionalExtensions.cs
+++ b/src/Narochno.Primitives/OptionalExtensions.cs
@@ -11,13 +11,13 @@
         public static Optional<TType> Fallback<TType>(this Optional<TType> value, Optional<TType> fallback)
             where TType : class
         {
-            return value.IsSet ? value.Value : fallback;
+            return value.HasValue ? value.Value : fallback;
         }
 
         public static TType Unwrap<TType>(this Optional<TType> value)
             where TType : class
         {
-            return value.IsSet ? value.Value : default(TType);
+            return value.HasValue ? value.Value : default(TType);
         }
     }
 }

--- a/src/Narochno.Primitives/OptionalExtensions.cs
+++ b/src/Narochno.Primitives/OptionalExtensions.cs
@@ -15,13 +15,9 @@
         }
 
         public static TType Unwrap<TType>(this Optional<TType> value)
+            where TType : class
         {
             return value.IsSet ? value.Value : default(TType);
-        }
-
-        public static TType? Nullable<TType>(this Optional<TType> value) where TType : struct
-        {
-            return value.IsSet ? value.Value : (TType?)null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/DefaultParserLibrary.cs
+++ b/src/Narochno.Primitives/Parsing/DefaultParserLibrary.cs
@@ -37,7 +37,7 @@ namespace Narochno.Primitives.Parsing
             // so each one gets a parser
             if (type.GetTypeInfo().IsEnum)
             {
-                Parsers.Add(type, new EnumParser(type));
+                Parsers.Add(type, (IParser)Activator.CreateInstance(typeof(EnumParser<>).MakeGenericType(type)));
                 return Parsers[type];
             }
 

--- a/src/Narochno.Primitives/Parsing/IParser.cs
+++ b/src/Narochno.Primitives/Parsing/IParser.cs
@@ -12,7 +12,7 @@
         /// </summary>
         /// <param name="input">The input string to convert from</param>
         /// <returns>A converted <typeparamref name="TType"/> object</returns>
-        IOptional TryParse(string input);
+        object TryParse(string input);
 
         /// <summary>
         /// Convert from <paramref name="input"/> to the type <typeparamref name="TType"/>

--- a/src/Narochno.Primitives/Parsing/Parser.cs
+++ b/src/Narochno.Primitives/Parsing/Parser.cs
@@ -5,9 +5,10 @@
     /// </summary>
     /// <typeparam name="TType">The type this class will parse</typeparam>
     public abstract class Parser<TType> : IParser
+        where TType : struct 
     {
         object IParser.Parse(string input) => Parse(input);
-        IOptional IParser.TryParse(string input) => TryParse(input);
+        object IParser.TryParse(string input) => TryParse(input);
 
         /// <summary>
         /// Convert from <paramref name="input"/> to the type <typeparamref name="TType"/>
@@ -23,6 +24,6 @@
         /// </summary>
         /// <param name="input">The input string to convert from</param>
         /// <returns>An <see cref="Optional{TType}" /></returns>
-        public abstract Optional<TType> TryParse(string input);
+        public abstract TType? TryParse(string input);
     }
 }

--- a/src/Narochno.Primitives/Parsing/ParserExtensions.cs
+++ b/src/Narochno.Primitives/Parsing/ParserExtensions.cs
@@ -2,18 +2,14 @@
 {
     public static class ParserExtensions
     {
-        public static Optional<TType> TryParse<TType>(this IParser parser, string input)
+        public static TType? TryParse<TType>(this IParser parser, string input)
+            where TType : struct 
         {
-            var result = parser.TryParse(input);
-            if (result.IsSet)
-            {
-                return (TType)result.Value;
-            }
-
-            return new Optional<TType>();
+            return (TType?)parser.TryParse(input);
         }
 
         public static TType Parse<TType>(this IParser parser, string input)
+            where TType : struct
         {
             return (TType)parser.Parse(input);
         }

--- a/src/Narochno.Primitives/Parsing/Parsers/BoolParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/BoolParser.cs
@@ -4,7 +4,7 @@
     {
         public override bool Parse(string input) => bool.Parse(input);
 
-        public override Optional<bool> TryParse(string input)
+        public override bool? TryParse(string input)
         {
             bool result;
             if (bool.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<bool>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/CharParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/CharParser.cs
@@ -4,7 +4,7 @@
     {
         public override char Parse(string input) => char.Parse(input);
 
-        public override Optional<char> TryParse(string input)
+        public override char? TryParse(string input)
         {
             char result;
             if (char.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<char>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/DecimalParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/DecimalParser.cs
@@ -4,7 +4,7 @@
     {
         public override decimal Parse(string input) => decimal.Parse(input);
 
-        public override Optional<decimal> TryParse(string input)
+        public override decimal? TryParse(string input)
         {
             decimal result;
             if (decimal.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<decimal>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/DoubleParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/DoubleParser.cs
@@ -4,7 +4,7 @@
     {
         public override double Parse(string input) => double.Parse(input);
 
-        public override Optional<double> TryParse(string input)
+        public override double? TryParse(string input)
         {
             double result;
             if (double.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<double>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/EnumParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/EnumParser.cs
@@ -4,18 +4,19 @@ using System.Reflection;
 
 namespace Narochno.Primitives.Parsing.Parsers
 {
-    public class EnumParser : Parser<Enum>
+    public class EnumParser<T>: Parser<T>
+        where T : struct 
     {
         public Type Type { get; }
-        public IList<Enum> Values { get; } = new List<Enum>();
-        public IDictionary<string, Enum> EnumStrings { get; } = new Dictionary<string, Enum>();
+        public List<T> Values { get; } = new List<T>();
+        public IDictionary<string, T> EnumStrings { get; } = new Dictionary<string, T>();
 
-        public EnumParser(Type type)
+        public EnumParser()
         {
-            Type = type;
-            foreach (var value in Enum.GetValues(type))
+            Type = typeof(T);
+            foreach (var value in Enum.GetValues(Type))
             {
-                Values.Add((Enum)value);
+                Values.Add((T)value);
             }
 
             // Cache this as it's expensive to fetch
@@ -24,12 +25,12 @@ namespace Narochno.Primitives.Parsing.Parsers
                 foreach (var attribute in Type.GetField(Enum.GetName(Type, value))
                     .GetCustomAttributes<EnumStringAttribute>())
                 {
-                    EnumStrings.Add(attribute.Value, value);
+                    EnumStrings.Add(attribute.Value, (T)value);
                 }
             }
         }
 
-        public override Enum Parse(string input)
+        public override T Parse(string input)
         {
             // First try to get the fields with EnumMemberAttribute
             if (input != null && EnumStrings.ContainsKey(input))
@@ -38,10 +39,10 @@ namespace Narochno.Primitives.Parsing.Parsers
             }
 
             // Fallback to the real Enum.Parse
-            return (Enum)Enum.Parse(Type, input);
+            return (T)Enum.Parse(Type, input);
         }
 
-        public override Optional<Enum> TryParse(string input)
+        public override T? TryParse(string input)
         {
             // First try to get the fields with EnumMemberAttribute
             if (input != null && EnumStrings.ContainsKey(input))
@@ -59,7 +60,7 @@ namespace Narochno.Primitives.Parsing.Parsers
                 }
             }
 
-            return new Optional<Enum>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/FloatParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/FloatParser.cs
@@ -4,7 +4,7 @@
     {
         public override float Parse(string input) => float.Parse(input);
 
-        public override Optional<float> TryParse(string input)
+        public override float? TryParse(string input)
         {
             float result;
             if (float.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<float>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/GuidParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/GuidParser.cs
@@ -6,7 +6,7 @@ namespace Narochno.Primitives.Parsing.Parsers
     {
         public override Guid Parse(string input) => Guid.Parse(input);
 
-        public override Optional<Guid> TryParse(string input)
+        public override Guid? TryParse(string input)
         {
             Guid result;
             if (Guid.TryParse(input, out result))
@@ -14,7 +14,7 @@ namespace Narochno.Primitives.Parsing.Parsers
                 return result;
             }
 
-            return new Optional<Guid>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/IntParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/IntParser.cs
@@ -4,7 +4,7 @@
     {
         public override int Parse(string input) => int.Parse(input);
 
-        public override Optional<int> TryParse(string input)
+        public override int? TryParse(string input)
         {
             int result;
             if (int.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<int>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/LongParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/LongParser.cs
@@ -4,7 +4,7 @@
     {
         public override long Parse(string input) => long.Parse(input);
 
-        public override Optional<long> TryParse(string input)
+        public override long? TryParse(string input)
         {
             long result;
             if (long.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<long>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/SByteParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/SByteParser.cs
@@ -4,7 +4,7 @@
     {
         public override sbyte Parse(string input) => sbyte.Parse(input);
 
-        public override Optional<sbyte> TryParse(string input)
+        public override sbyte? TryParse(string input)
         {
             sbyte result;
             if (sbyte.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<sbyte>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/ShortParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/ShortParser.cs
@@ -4,7 +4,7 @@
     {
         public override short Parse(string input) => short.Parse(input);
 
-        public override Optional<short> TryParse(string input)
+        public override short? TryParse(string input)
         {
             short result;
             if (short.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<short>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/UIntParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/UIntParser.cs
@@ -4,7 +4,7 @@
     {
         public override uint Parse(string input) => uint.Parse(input);
 
-        public override Optional<uint> TryParse(string input)
+        public override uint? TryParse(string input)
         {
             uint result;
             if (uint.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<uint>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/ULongParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/ULongParser.cs
@@ -4,7 +4,7 @@
     {
         public override ulong Parse(string input) => ulong.Parse(input);
 
-        public override Optional<ulong> TryParse(string input)
+        public override ulong? TryParse(string input)
         {
             ulong result;
             if (ulong.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<ulong>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/Parsers/UShortParser.cs
+++ b/src/Narochno.Primitives/Parsing/Parsers/UShortParser.cs
@@ -4,7 +4,7 @@
     {
         public override ushort Parse(string input) => ushort.Parse(input);
 
-        public override Optional<ushort> TryParse(string input)
+        public override ushort? TryParse(string input)
         {
             ushort result;
             if (ushort.TryParse(input, out result))
@@ -12,7 +12,7 @@
                 return result;
             }
 
-            return new Optional<ushort>();
+            return null;
         }
     }
 }

--- a/src/Narochno.Primitives/Parsing/StringExtensions.cs
+++ b/src/Narochno.Primitives/Parsing/StringExtensions.cs
@@ -10,7 +10,8 @@ namespace Narochno.Primitives.Parsing
         /// <typeparam name="TType">The type to convert to</typeparam>
         /// <param name="input">The input string</param>
         /// <returns>The Optional <typeparamref name="TType"/> parsed from the string <paramref name="input"/></returns>
-        public static Optional<TType> TryParse<TType>(this string input)
+        public static TType? TryParse<TType>(this string input)
+            where TType : struct 
         {
             return DefaultParserLibrary.Instance.GetParser<TType>()
                 .TryParse<TType>(input);
@@ -22,7 +23,7 @@ namespace Narochno.Primitives.Parsing
         /// <param name="input">The input string</param>
         /// <param name="type">The type to convert to</param>
         /// <returns>The IOptional parsed from the string <paramref name="input"/></returns>
-        public static IOptional TryParse(this string input, Type type)
+        public static object TryParse(this string input, Type type)
         {
             return DefaultParserLibrary.Instance.GetParser(type)
                 .TryParse(input);
@@ -35,6 +36,7 @@ namespace Narochno.Primitives.Parsing
         /// <param name="input">The input string</param>
         /// <returns>The type <typeparamref name="TType"/> parsed from the string <paramref name="input"/></returns>
         public static TType Parse<TType>(this string input)
+            where TType : struct 
         {
             return DefaultParserLibrary.Instance.GetParser<TType>()
                 .Parse<TType>(input);

--- a/src/Narochno.Primitives/project.json
+++ b/src/Narochno.Primitives/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.5.0",
+  "version": "2.0.0",
 
   "authors": [ "alanedwardes","adamhathcock" ],
 

--- a/src/Narochno.Primitives/project.json
+++ b/src/Narochno.Primitives/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "version": "1.1.0",
 
-  "authors": [ "alanedwardes" ],
+  "authors": [ "alanedwardes","adamhathcock" ],
 
   "packOptions": {
     "tags": [ "primitives" ],
@@ -11,11 +11,12 @@
   "dependencies": {
   },
 
-  "frameworks": {
-    "netstandard1.3": {
-      "dependencies": {
-        "System.Runtime": "4.3.0"
-      }
+    "frameworks": {
+        "netstandard1.3": {
+            "dependencies": {
+                "System.Runtime": "4.3.0",
+                "System.Runtime.Extensions": "4.3.0"
+            }
+        }
     }
-  }
 }

--- a/test/Narochno.Primitives.Json.Tests/OptionalJsonConverterTests.cs
+++ b/test/Narochno.Primitives.Json.Tests/OptionalJsonConverterTests.cs
@@ -8,7 +8,7 @@ namespace Narochno.Primitives.Json.Tests
         class TestClass
         {
             public Optional<string> String { get; set; }
-            public Optional<int> Integer { get; set; }
+            public int? Integer { get; set; }
         }
 
         class TestClassComplex

--- a/test/Narochno.Primitives.Tests/EnumParserTests.cs
+++ b/test/Narochno.Primitives.Tests/EnumParserTests.cs
@@ -58,9 +58,9 @@ namespace Narochno.Primitives.Parsing.Tests
         [Fact]
         public void TestParseInvalidToOptional()
         {
-            Assert.False("lol".TryParse<TestEnum>().IsSet);
-            Assert.False(string.Empty.TryParse<TestEnum>().IsSet);
-            Assert.False(((string)null).TryParse<TestEnum>().IsSet);
+            Assert.False("lol".TryParse<TestEnum>().HasValue);
+            Assert.False(string.Empty.TryParse<TestEnum>().HasValue);
+            Assert.False(((string)null).TryParse<TestEnum>().HasValue);
         }
     }
 }

--- a/test/Narochno.Primitives.Tests/OptionalEqualityTests.cs
+++ b/test/Narochno.Primitives.Tests/OptionalEqualityTests.cs
@@ -14,28 +14,10 @@ namespace Narochno.Primitives.Tests
         }
 
         [Fact]
-        public void TestStructNotSetAndSetEquality()
-        {
-            var one = new Optional<int>();
-            var two = 1.Optional();
-
-            Assert.False(one.Equals(two));
-        }
-
-        [Fact]
         public void TestClassNotSetEquality()
         {
             var one = new Optional<string>();
             var two = new Optional<string>();
-
-            Assert.True(one.Equals(two));
-        }
-
-        [Fact]
-        public void TestStructNotSetEquality()
-        {
-            var one = new Optional<int>();
-            var two = new Optional<int>();
 
             Assert.True(one.Equals(two));
         }
@@ -50,15 +32,6 @@ namespace Narochno.Primitives.Tests
         }
 
         [Fact]
-        public void TestStructEquality()
-        {
-            var one = 1.Optional();
-            var two = 1.Optional();
-
-            Assert.True(one.Equals(two));
-        }
-
-        [Fact]
         public void TestClassNonEquality()
         {
             var one = "one".Optional();
@@ -68,29 +41,10 @@ namespace Narochno.Primitives.Tests
         }
 
         [Fact]
-        public void TestStructNonEquality()
-        {
-            var one = 1.Optional();
-            var two = 2.Optional();
-
-            Assert.False(one.Equals(two));
-        }
-
-        [Fact]
         public void TestClassEqualityNonOptional()
         {
             var one = "one".Optional();
             var two = "one";
-
-            Assert.True(one.Equals(two));
-            Assert.False(two.Equals(one));
-        }
-
-        [Fact]
-        public void TestStructEqualityNonOptional()
-        {
-            var one = 1.Optional();
-            var two = 1;
 
             Assert.True(one.Equals(two));
             Assert.False(two.Equals(one));

--- a/test/Narochno.Primitives.Tests/OptionalExtensionsTests.cs
+++ b/test/Narochno.Primitives.Tests/OptionalExtensionsTests.cs
@@ -14,15 +14,6 @@ namespace Narochno.Primitives.Tests
         }
 
         [Fact]
-        public void TestStructToOptional()
-        {
-            var optional = 42.Optional();
-
-            Assert.True(optional.IsSet);
-            Assert.Equal(42, optional.Value);
-        }
-
-        [Fact]
         public void TestFallback()
         {
             var missing = new Optional<string>();

--- a/test/Narochno.Primitives.Tests/OptionalExtensionsTests.cs
+++ b/test/Narochno.Primitives.Tests/OptionalExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace Narochno.Primitives.Tests
         {
             var optional = "test".Optional();
 
-            Assert.True(optional.IsSet);
+            Assert.True(optional.HasValue);
             Assert.Equal("test", optional.Value);
         }
 
@@ -20,7 +20,7 @@ namespace Narochno.Primitives.Tests
             var missing = new Optional<string>();
 
             var result = missing.Fallback("fallback");
-            Assert.True(result.IsSet);
+            Assert.True(result.HasValue);
             Assert.Equal("fallback", result.Value);
         }
 
@@ -30,7 +30,7 @@ namespace Narochno.Primitives.Tests
             var existing = "test".Optional();
 
             var result = existing.Fallback("fallback");
-            Assert.True(result.IsSet);
+            Assert.True(result.HasValue);
             Assert.Equal("test", result.Value);
         }
 

--- a/test/Narochno.Primitives.Tests/OptionalExtensionsTests.cs
+++ b/test/Narochno.Primitives.Tests/OptionalExtensionsTests.cs
@@ -51,40 +51,5 @@ namespace Narochno.Primitives.Tests
 
             Assert.Null(result.Unwrap());
         }
-
-        [Fact]
-        public void TestUnwrapStruct()
-        {
-            var original = 1;
-
-            var missing = original.Optional();
-
-            Assert.Equal<int>(original, missing.Unwrap());
-        }
-
-        [Fact]
-        public void TestUnwrapMissingStruct()
-        {
-            var result = new Optional<Guid>();
-
-            Assert.Equal<Guid>(Guid.Empty, result.Unwrap());
-        }
-
-        [Fact]
-        public void ToNullableMissingTest()
-        {
-            var original = new Optional<int>().Nullable();
-
-            Assert.False(original.HasValue);
-        }
-
-        [Fact]
-        public void ToNillableTest()
-        {
-            var original = 1.Optional().Nullable();
-
-            Assert.True(original.HasValue);
-            Assert.Equal(1, original.Value);
-        }
     }
 }

--- a/test/Narochno.Primitives.Tests/OptionalTests.cs
+++ b/test/Narochno.Primitives.Tests/OptionalTests.cs
@@ -8,11 +8,11 @@ namespace Narochno.Primitives.Tests
         class TestClass { public override string ToString() => "test class"; }
 
         [Fact]
-        public void TestOptionalClassIsSet()
+        public void TestOptionalClassHasValue()
         {
             var test = new TestClass().Optional();
-            Assert.True(test.IsSet);
-            Assert.False(test.NotSet);
+            Assert.True(test.HasValue);
+            Assert.False(test.HasNoValue);
         }
 
         [Fact]
@@ -23,22 +23,22 @@ namespace Narochno.Primitives.Tests
         }
 
         [Fact]
-        public void TestOptionalNotSetToString()
+        public void TestOptionalHasNoValueToString()
         {
             var test = new Optional<TestClass>();
             Assert.Equal("Not Set", test.ToString());
         }
 
         [Fact]
-        public void TestOptionalNotSet()
+        public void TestOptionalHasNoValue()
         {
             var test = new Optional<TestClass>();
-            Assert.False(test.IsSet);
-            Assert.True(test.NotSet);
+            Assert.False(test.HasValue);
+            Assert.True(test.HasNoValue);
         }
 
         [Fact]
-        public void TestOptionalNotSetValueException()
+        public void TestOptionalHasNoValueValueException()
         {
             var test = new Optional<TestClass>();
             Assert.Throws<InvalidOperationException>(() => test.Value);
@@ -51,8 +51,8 @@ namespace Narochno.Primitives.Tests
             // A method that accepts an optional
             new Action<Optional<TestClass>>(x =>
             {
-                Assert.True(x.IsSet);
-                Assert.False(x.NotSet);
+                Assert.True(x.HasValue);
+                Assert.False(x.HasNoValue);
                 Assert.Same(test, x.Value);
             })(test);
         }
@@ -61,16 +61,16 @@ namespace Narochno.Primitives.Tests
         public void TestOptionalCastToValue()
         {
             var test = (Optional<TestClass>)new TestClass();
-            Assert.True(test.IsSet);
-            Assert.False(test.NotSet);
+            Assert.True(test.HasValue);
+            Assert.False(test.HasNoValue);
         }
 
         [Fact]
         public void TestOptionalCastToNoValue()
         {
             var test = (Optional<TestClass>)null;
-            Assert.False(test.IsSet);
-            Assert.True(test.NotSet);
+            Assert.False(test.HasValue);
+            Assert.True(test.HasNoValue);
         }
     }
 }

--- a/test/Narochno.Primitives.Tests/OptionalTests.cs
+++ b/test/Narochno.Primitives.Tests/OptionalTests.cs
@@ -6,7 +6,6 @@ namespace Narochno.Primitives.Tests
     public class OptionalTests
     {
         class TestClass { public override string ToString() => "test class"; }
-        struct TestStruct { public override string ToString() => "test struct"; }
 
         [Fact]
         public void TestOptionalClassIsSet()
@@ -21,22 +20,6 @@ namespace Narochno.Primitives.Tests
         {
             var test = new TestClass().Optional();
             Assert.Equal("test class", test.ToString());
-        }
-
-        [Fact]
-        public void TestOptionalStructIsSet()
-        {
-            var test = new TestStruct().Optional();
-            Assert.True(test.IsSet);
-            Assert.False(test.NotSet);
-        }
-
-        [Fact]
-        public void TestOptionalStructNotSet()
-        {
-            var test = new Optional<TestStruct>();
-            Assert.False(test.IsSet);
-            Assert.True(test.NotSet);
         }
 
         [Fact]
@@ -72,6 +55,22 @@ namespace Narochno.Primitives.Tests
                 Assert.False(x.NotSet);
                 Assert.Same(test, x.Value);
             })(test);
+        }
+
+        [Fact]
+        public void TestOptionalCastToValue()
+        {
+            var test = (Optional<TestClass>)new TestClass();
+            Assert.True(test.IsSet);
+            Assert.False(test.NotSet);
+        }
+
+        [Fact]
+        public void TestOptionalCastToNoValue()
+        {
+            var test = (Optional<TestClass>)null;
+            Assert.False(test.IsSet);
+            Assert.True(test.NotSet);
         }
     }
 }

--- a/test/Narochno.Primitives.Tests/PrimitiveParserTests.cs
+++ b/test/Narochno.Primitives.Tests/PrimitiveParserTests.cs
@@ -5,6 +5,10 @@ namespace Narochno.Primitives.Parsing.Tests
 {
     public class PrimitiveParserTests
     {
+        public struct MyStruct
+        {
+            
+        }
         [Theory]
         [InlineData(typeof(bool), "true", true)]
         [InlineData(typeof(bool), "false", false)]
@@ -33,7 +37,7 @@ namespace Narochno.Primitives.Parsing.Tests
         public void Parse(Type type, string input, object expected)
         {
             Assert.Equal(expected, input.Parse(type));
-            Assert.Equal(expected, input.TryParse(type).Value);
+            Assert.Equal(expected, input.TryParse(type));
         }
 
         [Fact]
@@ -46,8 +50,8 @@ namespace Narochno.Primitives.Parsing.Tests
         [Fact]
         public void UnknownType()
         {
-            Assert.Throws<ArgumentException>(() => "test".Parse<PrimitiveParserTests>());
-            Assert.Throws<ArgumentException>(() => "test".TryParse<PrimitiveParserTests>());
+            Assert.Throws<ArgumentException>(() => "test".Parse<MyStruct>());
+            Assert.Throws<ArgumentException>(() => "test".TryParse<MyStruct>());
         }
     }
 }


### PR DESCRIPTION
- Optional should only work on classes, otherwise use Nullable.
- Changed parsing to use Nullables.
- Renamed IsSet/IsNotSet to HasValue/HasNoValue to match Nullable.
- Fixed issue where if you cast a null to a type of Optional, it shouldn't see it has having a value.
- Added Hex extensions.